### PR TITLE
Add database seed module

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -75,18 +75,18 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "rocc:build"
+            "browserTarget": "rocc-app:build"
           },
           "configurations": {
             "production": {
-              "browserTarget": "rocc:build:production"
+              "browserTarget": "rocc-app:build:production"
             }
           }
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
           "options": {
-            "browserTarget": "rocc:build"
+            "browserTarget": "rocc-app:build"
           }
         },
         "test": {
@@ -129,16 +129,16 @@
           "builder": "@angular-devkit/build-angular:protractor",
           "options": {
             "protractorConfig": "e2e/protractor.conf.js",
-            "devServerTarget": "rocc:serve"
+            "devServerTarget": "rocc-app:serve"
           },
           "configurations": {
             "production": {
-              "devServerTarget": "rocc:serve:production"
+              "devServerTarget": "rocc-app:serve:production"
             }
           }
         }
       }
     }
   },
-  "defaultProject": "rocc"
+  "defaultProject": "rocc-app"
 }

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -5,6 +5,7 @@
     "changeOrigin": true,
     "pathRewrite": {
       "^/api": ""
-    }
+    },
+    "logLevel": "debug"
   }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,6 +3,7 @@
   [sections]="sections"
 ></sage-navbar>
 <router-outlet></router-outlet>
+<rocc-database-seed *ngIf="seedDatabase"></rocc-database-seed>
 
 <!-- <nav class="toolbar" role="banner">
   <img width="40" alt="ROCC Logo"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -15,6 +15,7 @@ export class AppComponent implements OnInit {
   title = 'ROCC';
   version = environment.appVersion;
   sections: { [key: string]: Section } = SECTIONS;
+  seedDatabase = environment.seedDatabase;
 
   constructor() {}
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { BASE_PATH } from '@sage-bionetworks/rocc-client-angular';
 
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
+import { DatabaseSeedModule } from './components/database-seed/database-seed.module';
 import { environment } from '../environments/environment';
 
 export function apiConfigFactory(): Configuration {
@@ -29,7 +30,8 @@ export function apiConfigFactory(): Configuration {
     AppRoutingModule,
     NavbarModule,
     FooterModule,
-    ApiModule.forRoot(apiConfigFactory)
+    ApiModule.forRoot(apiConfigFactory),
+    DatabaseSeedModule
   ],
   providers: [
     { provide: BASE_PATH, useValue: environment.apiBasePath }

--- a/src/app/components/database-seed/database-seed.component.html
+++ b/src/app/components/database-seed/database-seed.component.html
@@ -1,0 +1,1 @@
+<p>database-seed works!</p>

--- a/src/app/components/database-seed/database-seed.component.spec.ts
+++ b/src/app/components/database-seed/database-seed.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DatabaseSeedComponent } from './database-seed.component';
+
+describe('DatabaseSeedComponent', () => {
+  let component: DatabaseSeedComponent;
+  let fixture: ComponentFixture<DatabaseSeedComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DatabaseSeedComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DatabaseSeedComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/database-seed/database-seed.component.ts
+++ b/src/app/components/database-seed/database-seed.component.ts
@@ -16,7 +16,7 @@ export class DatabaseSeedComponent implements OnInit {
     //     console.log(res);
     //   },
     //   err => console.error(err));
-    this.tagService.createTag("plop-tag", {})
+    this.tagService.createTag('plop-tag', {})
       .subscribe(res => {
         console.log(res);
       },

--- a/src/app/components/database-seed/database-seed.component.ts
+++ b/src/app/components/database-seed/database-seed.component.ts
@@ -1,0 +1,20 @@
+import { Component, OnInit } from '@angular/core';
+import { TagService } from '@sage-bionetworks/rocc-client-angular';
+
+@Component({
+  selector: 'rocc-database-seed',
+  templateUrl: './database-seed.component.html',
+  styleUrls: ['./database-seed.component.scss']
+})
+export class DatabaseSeedComponent implements OnInit {
+
+  constructor(private tagService: TagService) {}
+
+  ngOnInit(): void {
+    this.tagService.deleteAllTags()
+      .subscribe(res => {
+        console.log(res);
+      },
+      err => console.error(err));
+  }
+}

--- a/src/app/components/database-seed/database-seed.component.ts
+++ b/src/app/components/database-seed/database-seed.component.ts
@@ -11,10 +11,16 @@ export class DatabaseSeedComponent implements OnInit {
   constructor(private tagService: TagService) {}
 
   ngOnInit(): void {
-    this.tagService.deleteAllTags()
+    // this.tagService.deleteAllTags()
+    //   .subscribe(res => {
+    //     console.log(res);
+    //   },
+    //   err => console.error(err));
+    this.tagService.createTag("plop-tag", {})
       .subscribe(res => {
         console.log(res);
       },
-      err => console.error(err));
+      err => console.error(err)
+    );
   }
 }

--- a/src/app/components/database-seed/database-seed.module.ts
+++ b/src/app/components/database-seed/database-seed.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TagService } from '@sage-bionetworks/rocc-client-angular';
+import { DatabaseSeedComponent } from './database-seed.component';
+
+@NgModule({
+  declarations: [DatabaseSeedComponent],
+  imports: [CommonModule],
+  exports: [DatabaseSeedComponent],
+  providers: [TagService]
+})
+export class DatabaseSeedModule {}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: true,
   apiBasePath: 'http://localhost:4200/api',  // see proxy.conf.json
-  appVersion: '0.1.0'
+  appVersion: '0.1.0',
+  seedDatabase: false
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,7 +5,8 @@
 export const environment = {
     production: false,
     apiBasePath: 'http://localhost:4200/api',  // see proxy.conf.json
-    appVersion: '0.1.0'
+    appVersion: '0.1.0',
+    seedDatabase: true
 };
 
 /*


### PR DESCRIPTION
Fixes #40 

### Solution

It's actually possible to add `required` to [this requestBody](https://github.com/Sage-Bionetworks/rocc-schemas/blob/e4b6747739e8e87ac4b618188b3356c85e78e593/openapi/paths/tags.yaml#L14) and similar ones. I believe that the OpenAPI generator would then correctly generate the rocc-client-angular in a way that the service will tell us that the request body is required. Note that currently none of the Tag properties are marked as required. The error is thrown because of our implementation of the API service, where the implementation actually [requires an object to be specified](https://github.com/Sage-Bionetworks/rocc/blob/c8c7e8e58097a5601be02e095fb17877ed45f508/server/openapi_server/controllers/tag_controller.py#L25) otherwise it returns a 400 error. Then instead of changing the schema, I will probably update the implementation of the API service to make life easier to the user (i.e. no need to specify empty object). Meanwhile, please specify the empty object in the ROCC app.