### PR TITLE
Remove all documents from the database

### DIFF
--- a/src/app/components/database-seed/database-seed.component.ts
+++ b/src/app/components/database-seed/database-seed.component.ts
@@ -1,5 +1,11 @@
 import { Component, OnInit } from '@angular/core';
-import { TagService } from '@sage-bionetworks/rocc-client-angular';
+import { forkJoin } from 'rxjs';
+import {
+  ChallengeService,
+  OrganizationService,
+  PersonService,
+  TagService
+} from '@sage-bionetworks/rocc-client-angular';
 
 @Component({
   selector: 'rocc-database-seed',
@@ -8,19 +14,31 @@ import { TagService } from '@sage-bionetworks/rocc-client-angular';
 })
 export class DatabaseSeedComponent implements OnInit {
 
-  constructor(private tagService: TagService) {}
+  constructor(private challengeService: ChallengeService,
+    private organizationService: OrganizationService,
+    private personService: PersonService,
+    private tagService: TagService) {}
 
   ngOnInit(): void {
+    const removeAllDocuments$ = forkJoin([
+      this.challengeService.deleteAllChallenges(),
+      this.organizationService.deleteAllOrganizations(),
+      this.personService.deleteAllPersons(),
+      this.tagService.deleteAllTags(),
+    ]);
+
+    removeAllDocuments$.subscribe(console.log);
+
     // this.tagService.deleteAllTags()
     //   .subscribe(res => {
     //     console.log(res);
     //   },
     //   err => console.error(err));
-    this.tagService.createTag('plop-tag', {})
-      .subscribe(res => {
-        console.log(res);
-      },
-      err => console.error(err)
-    );
+    // this.tagService.createTag('plop-tag', {})
+    //   .subscribe(res => {
+    //     console.log(res);
+    //   },
+    //   err => console.error(err)
+    // );
   }
 }

--- a/src/app/components/database-seed/database-seed.component.ts
+++ b/src/app/components/database-seed/database-seed.component.ts
@@ -14,10 +14,12 @@ import {
 })
 export class DatabaseSeedComponent implements OnInit {
 
-  constructor(private challengeService: ChallengeService,
+  constructor(
+    private challengeService: ChallengeService,
     private organizationService: OrganizationService,
     private personService: PersonService,
-    private tagService: TagService) {}
+    private tagService: TagService
+  ) {}
 
   ngOnInit(): void {
     const removeAllDocuments$ = forkJoin([


### PR DESCRIPTION
Fixes #43

### Solution

The operator `forkJoin` takes as input an array or dictionary of observables and emit only once when all the observables have completed. Here we assume that the DB collections can be emptied in any order. Here the observables passed as input to `forkJoin` are run concurrently.

The current implementation is limited to the first group of schemas we are focusing on: tags, challenges, organization, persons.

Browser console output:

```
Array(4) [ {}, {}, {}, {} ]
```

These four empty objects are the objects returned by the DELETE endpoints of the four object type (tags, challenges, organization, persons).