### PR TITLE
Seed tags concurrently

### DIFF
--- a/src/app/components/database-seed/database-seed.component.ts
+++ b/src/app/components/database-seed/database-seed.component.ts
@@ -1,12 +1,13 @@
 import { Component, OnInit } from '@angular/core';
-import { forkJoin } from 'rxjs';
-import { mergeMap } from 'rxjs/operators';
+import { forkJoin, from } from 'rxjs';
+import { mergeMap, bufferCount } from 'rxjs/operators';
 import {
   ChallengeService,
   OrganizationService,
   PersonService,
   TagService
 } from '@sage-bionetworks/rocc-client-angular';
+import { Tag } from '@sage-bionetworks/rocc-client-angular';
 import tagList from '../../seeds/dream/tags.json';
 
 @Component({
@@ -31,8 +32,10 @@ export class DatabaseSeedComponent implements OnInit {
       this.tagService.deleteAllTags(),
     ]);
 
+    const tags: Tag[] = tagList.tags;
+
     const addTags$ = forkJoin(
-      tagList.tags.map(tag => this.tagService.createTag(tag.id, {}))
+      tags.map(tag => this.tagService.createTag(tag.tagId, {}))
     );
 
     removeDocuments$

--- a/src/app/components/database-seed/database-seed.component.ts
+++ b/src/app/components/database-seed/database-seed.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { forkJoin, from } from 'rxjs';
-import { mergeMap, bufferCount } from 'rxjs/operators';
+import { forkJoin } from 'rxjs';
+import { mergeMap, tap } from 'rxjs/operators';
 import {
   ChallengeService,
   OrganizationService,
@@ -32,14 +32,21 @@ export class DatabaseSeedComponent implements OnInit {
       this.tagService.deleteAllTags(),
     ]);
 
-    const tags: Tag[] = tagList.tags;
+    // const tags: Tag[] = tagList.tags;
+    const tags = tagList.tags; // TODO: replace by above line when Tag.tagId is no longer optional
 
     const addTags$ = forkJoin(
       tags.map(tag => this.tagService.createTag(tag.tagId, {}))
     );
 
     removeDocuments$
-      .pipe(mergeMap(() => addTags$))
-      .subscribe(console.log);
+      .pipe(
+        mergeMap(() => addTags$),
+        tap(console.log),
+        // mergeMap(() => addPersons$)
+      )
+      .subscribe(res => {
+        console.log('done', res);
+      }, err => console.log);
   }
 }

--- a/src/app/seeds/dream/tags.json
+++ b/src/app/seeds/dream/tags.json
@@ -130,7 +130,7 @@
       "tagId": "metadata"
     },
     {
-      "tagId": "covtagId"
+      "tagId": "covid"
     },
     {
       "tagId": "pd1"

--- a/src/app/seeds/dream/tags.json
+++ b/src/app/seeds/dream/tags.json
@@ -1,151 +1,151 @@
 {
   "tags": [
     {
-      "id": "drug"
+      "tagId": "drug"
     },
     {
-      "id": "toxicogenenetics"
+      "tagId": "toxicogenenetics"
     },
     {
-      "id": "whole-cell-parameter"
+      "tagId": "whole-cell-parameter"
     },
     {
-      "id": "cancer"
+      "tagId": "cancer"
     },
     {
-      "id": "breast-cancer"
+      "tagId": "breast-cancer"
     },
     {
-      "id": "network-inference"
+      "tagId": "network-inference"
     },
     {
-      "id": "signaling"
+      "tagId": "signaling"
     },
     {
-      "id": "arthritis"
+      "tagId": "arthritis"
     },
     {
-      "id": "rheumatoid-arthritis"
+      "tagId": "rheumatoid-arthritis"
     },
     {
-      "id": "mutation-calling"
+      "tagId": "mutation-calling"
     },
     {
-      "id": "aml"
+      "tagId": "aml"
     },
     {
-      "id": "targeted-cancer-therapy"
+      "tagId": "targeted-cancer-therapy"
     },
     {
-      "id": "alzheimers"
+      "tagId": "alzheimers"
     },
     {
-      "id": "olfaction"
+      "tagId": "olfaction"
     },
     {
-      "id": "prostate-cancer"
+      "tagId": "prostate-cancer"
     },
     {
-      "id": "als"
+      "tagId": "als"
     },
     {
-      "id": "drug-synergy"
+      "tagId": "drug-synergy"
     },
     {
-      "id": "somatic-mutation-calling"
+      "tagId": "somatic-mutation-calling"
     },
     {
-      "id": "tumor-heterogeneity"
+      "tagId": "tumor-heterogeneity"
     },
     {
-      "id": "viral"
+      "tagId": "viral"
     },
     {
-      "id": "respiratory-viral"
+      "tagId": "respiratory-viral"
     },
     {
-      "id": "module-identification"
+      "tagId": "module-identification"
     },
     {
-      "id": "transcription-factor"
+      "tagId": "transcription-factor"
     },
     {
-      "id": "proposals"
+      "tagId": "proposals"
     },
     {
-      "id": "human-health"
+      "tagId": "human-health"
     },
     {
-      "id": "mammography"
+      "tagId": "mammography"
     },
     {
-      "id": "myeloma"
+      "tagId": "myeloma"
     },
     {
-      "id": "workflow-execution"
+      "tagId": "workflow-execution"
     },
     {
-      "id": "parkinsons"
+      "tagId": "parkinsons"
     },
     {
-      "id": "proteogenomics"
+      "tagId": "proteogenomics"
     },
     {
-      "id": "multi-targeting-drug"
+      "tagId": "multi-targeting-drug"
     },
     {
-      "id": "transcriptomics"
+      "tagId": "transcriptomics"
     },
     {
-      "id": "single-cell"
+      "tagId": "single-cell"
     },
     {
-      "id": "drug-kinase-binding"
+      "tagId": "drug-kinase-binding"
     },
     {
-      "id": "malaria"
+      "tagId": "malaria"
     },
     {
-      "id": "preterm-birth"
+      "tagId": "preterm-birth"
     },
     {
-      "id": "ehr"
+      "tagId": "ehr"
     },
     {
-      "id": "nlp"
+      "tagId": "nlp"
     },
     {
-      "id": "crispr"
+      "tagId": "crispr"
     },
     {
-      "id": "cell-lineage"
+      "tagId": "cell-lineage"
     },
     {
-      "id": "tumor-deconvolution"
+      "tagId": "tumor-deconvolution"
     },
     {
-      "id": "panacea"
+      "tagId": "panacea"
     },
     {
-      "id": "metadata"
+      "tagId": "metadata"
     },
     {
-      "id": "covid"
+      "tagId": "covtagId"
     },
     {
-      "id": "pd1"
+      "tagId": "pd1"
     },
     {
-      "id": "network-topology"
+      "tagId": "network-topology"
     },
     {
-      "id": "parameter-inference"
+      "tagId": "parameter-inference"
     },
     {
-      "id": "breast"
+      "tagId": "breast"
     },
     {
-      "id": "drug-sensitivity"
+      "tagId": "drug-sensitivity"
     }
   ]
 }


### PR DESCRIPTION
This PR enables the app to push tags to the API service concurrently using `forkJoin`.

### Notes

- This PR will be merged into #49 
- It is preferable to work with `Tag` objects than directly with the JSON objects. Converting JSON objects to Tags performs a validation of the data and an error is thrown if the JSON object does not match the requirements defined by the Tag object.
- The property `Tag.tagId` will soon be renamed `Tag.id`
- The property `Tag.id` will be made required
- Currently all the observables in a `forkJoin` are executed concurrently. It is OK so far because we don't have many objects (< 50 tags). However we may consider limiting the number of concurrent requests sent concurrently to the API service.
- This PR introduces the rxjs operators `mergeAll` and `tap`.
- The design of this solution can be extended to push objects as long as they don't depend on each others. When we will push Challenges objects, that depends on other objects, additional thinking will be required. For now we can use this solution to push first all the objects that have no dependencies.