### PR TITLE
Fix apiUrl in config.json

### DIFF
--- a/src/config/config.json
+++ b/src/config/config.json
@@ -1,6 +1,6 @@
 {
   "environment": "prod",
-  "apiUrl": "http://localhost/api",
+  "apiUrl": "http://localhost:4200/api",
   "appVersion": "0.2.0",
   "seedDatabase": false
 }


### PR DESCRIPTION
Fix config parameter `apiUrl` for development server. Works in combination with `proxy.conf.json`.