### PR TITLE
Add page title service and use it in most pages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
     schedule:
       interval: "monthly"
     target-branch: "main"
-    # Disable all pull requests for Docker dependencies
     open-pull-requests-limit: 0
 
   - package-ecosystem: "npm"
@@ -14,5 +13,4 @@ updates:
     schedule:
       interval: "monthly"
     target-branch: "main"
-    # Disable all pull requests for npm dependencies
     open-pull-requests-limit: 0

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -17,6 +17,7 @@ import { DatabaseSeedModule } from './components/database-seed/database-seed.mod
 import { FiltersModule } from './components/filters/filters.module';
 import { AppConfigService } from './app-config.service';
 import { AppConfig, APP_CONFIG } from './app.config';
+import { PageTitleModule } from './components/page-title/page-title.module';
 
 export function apiConfigFactory(): Configuration {
   const params: ConfigurationParameters = {
@@ -36,6 +37,7 @@ export function apiConfigFactory(): Configuration {
     ApiModule.forRoot(apiConfigFactory),
     DatabaseSeedModule,
     FiltersModule,
+    PageTitleModule
   ],
   declarations: [AppComponent],
   providers: [

--- a/src/app/components/page-title/page-title.mock.ts
+++ b/src/app/components/page-title/page-title.mock.ts
@@ -1,0 +1,3 @@
+export class PageTitleServiceStub {
+  renderTitle(): void {}
+}

--- a/src/app/components/page-title/page-title.module.ts
+++ b/src/app/components/page-title/page-title.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PageTitleService } from './page-title.service';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [],
+  providers: [PageTitleService],
+  exports: [],
+})
+export class PageTitleModule {}

--- a/src/app/components/page-title/page-title.service.ts
+++ b/src/app/components/page-title/page-title.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { BehaviorSubject, combineLatest, Subscription } from 'rxjs';
+
+@Injectable()
+export class PageTitleService implements OnDestroy {
+  private title: BehaviorSubject<string> = new BehaviorSubject<string>('');
+  private numNotifications: BehaviorSubject<number> =
+    new BehaviorSubject<number>(0);
+  private subscription!: Subscription;
+
+  static parameters = [Title];
+  constructor(private bodyTitle: Title) {
+    combineLatest([this.title, this.numNotifications]).subscribe(
+      ([title, numNotifications]) => {
+        title = title !== '' ? `${title}` : '';
+        let notification = numNotifications > 0 ? `(${numNotifications}) ` : '';
+        this.bodyTitle.setTitle(`${notification}${title}`);
+      },
+      (err) => console.error(err)
+    );
+  }
+
+  ngOnDestroy() {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
+  }
+
+  setTitle(title: string): void {
+    this.title.next(title);
+  }
+
+  setNumNotifications(numNotifications: number): void {
+    this.numNotifications.next(numNotifications);
+  }
+}

--- a/src/app/components/page-title/page-title.service.ts
+++ b/src/app/components/page-title/page-title.service.ts
@@ -9,19 +9,18 @@ export class PageTitleService implements OnDestroy {
     new BehaviorSubject<number>(0);
   private subscription!: Subscription;
 
-  static parameters = [Title];
   constructor(private bodyTitle: Title) {
     combineLatest([this.title, this.numNotifications]).subscribe(
       ([title, numNotifications]) => {
         title = title !== '' ? `${title}` : '';
-        let notification = numNotifications > 0 ? `(${numNotifications}) ` : '';
+        const notification = numNotifications > 0 ? `(${numNotifications}) ` : '';
         this.bodyTitle.setTitle(`${notification}${title}`);
       },
       (err) => console.error(err)
     );
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     if (this.subscription) {
       this.subscription.unsubscribe();
     }

--- a/src/app/pages/challenges/challenge-list/challenge-list.component.ts
+++ b/src/app/pages/challenges/challenge-list/challenge-list.component.ts
@@ -33,6 +33,7 @@ import {
 // import { shallowEqual } from '../../../shallowEqual';
 import deepEqual from 'deep-equal';
 import { ChallengeListQuery } from './challenge-list-query';
+import { PageTitleService } from 'src/app/components/page-title/page-title.service';
 // import { DateRange } from 'src/app/components/filters/date-range-filter/date-range';
 
 const emptyChallengeListQuery: ChallengeListQuery = {
@@ -74,12 +75,14 @@ export class ChallengeListComponent implements OnInit, AfterViewInit {
   constructor(
     private challengePlatformService: ChallengePlatformService,
     private challengeService: ChallengeService,
-    private tagService: TagService
+    private tagService: TagService,
+    private pageTitleService: PageTitleService
   ) {}
 
   ngOnInit(): void {
     this.listTags();
     this.listChallengePlatforms();
+    this.pageTitleService.setTitle('Challenges');
   }
 
   ngAfterViewInit(): void {

--- a/src/app/pages/challenges/challenge-view/challenge-view.component.ts
+++ b/src/app/pages/challenges/challenge-view/challenge-view.component.ts
@@ -1,8 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Observable } from 'rxjs';
-import { Challenge, ChallengeService } from '@sage-bionetworks/rocc-client-angular';
+import {
+  Challenge,
+  ChallengeService,
+} from '@sage-bionetworks/rocc-client-angular';
 import { switchMap } from 'rxjs/operators';
+import { PageTitleService } from 'src/app/components/page-title/page-title.service';
 
 @Component({
   selector: 'rocc-challenge-view',
@@ -12,9 +16,20 @@ import { switchMap } from 'rxjs/operators';
 export class ChallengeViewComponent implements OnInit {
   challenge$!: Observable<Challenge>;
 
-  constructor(private router: Router, private route: ActivatedRoute, private challengeService: ChallengeService) {}
+  constructor(
+    private router: Router,
+    private route: ActivatedRoute,
+    private challengeService: ChallengeService,
+    private pageTitleService: PageTitleService
+  ) {}
 
   ngOnInit(): void {
-    this.challenge$ = this.route.params.pipe(switchMap(params => this.challengeService.getChallenge(params.id)));
+    this.challenge$ = this.route.params.pipe(
+      switchMap((params) => this.challengeService.getChallenge(params.id))
+    );
+
+    this.challenge$.subscribe(challenge => {
+      this.pageTitleService.setTitle(challenge.name);
+    });
   }
 }

--- a/src/app/pages/homepage/homepage.component.ts
+++ b/src/app/pages/homepage/homepage.component.ts
@@ -1,6 +1,7 @@
 import { Component, HostBinding, OnInit, Input } from '@angular/core';
 import { AppConfigService } from 'src/app/app-config.service';
 import { AppConfig } from 'src/app/app.config';
+import { PageTitleService } from 'src/app/components/page-title/page-title.service';
 // import { AppConfigService, AppC } from 'src/app/app-config.service';
 
 @Component({
@@ -18,11 +19,12 @@ export class HomepageComponent implements OnInit {
   user = true;
   username = 'rocc-user';
 
-  constructor(private appConfigService: AppConfigService) {}
+  constructor(private appConfigService: AppConfigService, private pageTitleService: PageTitleService) {}
 
   ngOnInit(): void {
     this.appConfigService
       .getAppConfig()
       .subscribe((config) => (this.appConfig = config));
+    this.pageTitleService.setTitle('ROCC');
   }
 }

--- a/src/app/pages/organizations/organization-list/organization-list.component.ts
+++ b/src/app/pages/organizations/organization-list/organization-list.component.ts
@@ -1,15 +1,15 @@
 import { Component, OnInit } from '@angular/core';
+import { PageTitleService } from 'src/app/components/page-title/page-title.service';
 
 @Component({
   selector: 'rocc-organization-list',
   templateUrl: './organization-list.component.html',
-  styleUrls: ['./organization-list.component.scss']
+  styleUrls: ['./organization-list.component.scss'],
 })
 export class OrganizationListComponent implements OnInit {
-
-  constructor() { }
+  constructor(private pageTitleService: PageTitleService) {}
 
   ngOnInit(): void {
+    this.pageTitleService.setTitle('Organizations');
   }
-
 }

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Rocc</title>
+  <title>ROCC</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
This service enables to set the text displayed in the tab of a browser. This service can also be used to specify a number of ROCC notifications, which is a future feature. Page title format: `({numNotifications} {title})`.

Example: `(1) Awesome Challenge` shows that the user is on the page of the Awesome Challenge and that there is one (unread) notification. When the number of notifications are not set, the title of the page is just `{title}`.