### PR TITLE
Add user account settings module

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -27,6 +27,10 @@ export const routes: Routes = [
     loadChildren: () => import('./pages/notifications').then(m => m.NotificationsModule)
   },
   {
+    path: 'settings',
+    loadChildren: () => import('./pages/settings').then(m => m.SettingsModule)
+  },
+  {
     path: 'orgs',
     loadChildren: () => import('./pages/organization').then(m => m.OrganizationModule)
   },

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -64,7 +64,7 @@ export class AppComponent implements OnInit, OnDestroy {
   selectUserMenuItem(menuItem: MenuItem): void {
     console.log('Navbar user menu item selected', menuItem);
     if (menuItem.name === 'Sign out') {  // TODO DRY
-      this.authService.logout();
+      this.authService.signout();
     }
   }
 

--- a/src/app/pages/homepage/homepage.component.html
+++ b/src/app/pages/homepage/homepage.component.html
@@ -13,6 +13,11 @@
         </thead>
         <tbody>
           <tr>
+            <td>Sign In</td>
+            <td>Sign in to ROCC.</td>
+            <td><a mat-raised-button class="btn" routerLink="signin">/signin</a></td>
+          </tr>
+          <tr>
             <td>Sign Up</td>
             <td>Create a User account.</td>
             <td><a mat-raised-button class="btn" routerLink="signup">/signup</a></td>
@@ -46,6 +51,11 @@
             <td>Challenge Page (User)</td>
             <td>View a challenge hosted by a User.</td>
             <td><a mat-raised-button class="btn" color="accent" routerLink="awesome-user/awesome-challenge">awesome-user/awesome-challenge</a></td>
+          </tr>
+          <tr>
+            <td>User Settings</td>
+            <td>Manage your user account settings.</td>
+            <td><a mat-raised-button class="btn" routerLink="settings">/settings</a></td>
           </tr>
         </tbody>
       </table>

--- a/src/app/pages/settings/index.ts
+++ b/src/app/pages/settings/index.ts
@@ -1,0 +1,2 @@
+export * from './settings.component';
+export * from './settings.module';

--- a/src/app/pages/settings/settings-routing.module.ts
+++ b/src/app/pages/settings/settings-routing.module.ts
@@ -1,9 +1,10 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
+import { AuthGuard } from '@shared/auth/auth-guard.service';
 import { SettingsComponent } from './settings.component';
 
 const routes: Routes = [
-  { path: '', component: SettingsComponent },
+  { path: '', component: SettingsComponent, canActivate: [AuthGuard] },
   // {
   //   path: ':challengeName',
   //   loadChildren: () => import('../challenge').then((m) => m.ChallengeModule),

--- a/src/app/pages/settings/settings-routing.module.ts
+++ b/src/app/pages/settings/settings-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { SettingsComponent } from './settings.component';
+
+const routes: Routes = [
+  { path: '', component: SettingsComponent },
+  // {
+  //   path: ':challengeName',
+  //   loadChildren: () => import('../challenge').then((m) => m.ChallengeModule),
+  // },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class SettingsRoutingModule {}

--- a/src/app/pages/settings/settings.component.html
+++ b/src/app/pages/settings/settings.component.html
@@ -1,0 +1,5 @@
+<main>
+  <p>settings works!</p>
+</main>
+
+<sage-footer></sage-footer>

--- a/src/app/pages/settings/settings.component.scss
+++ b/src/app/pages/settings/settings.component.scss
@@ -1,0 +1,6 @@
+main {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}

--- a/src/app/pages/settings/settings.component.spec.ts
+++ b/src/app/pages/settings/settings.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SettingsComponent } from './settings.component';
+
+describe('SettingsComponent', () => {
+  let component: SettingsComponent;
+  let fixture: ComponentFixture<SettingsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SettingsComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/settings/settings.component.ts
+++ b/src/app/pages/settings/settings.component.ts
@@ -1,0 +1,14 @@
+import { Component, HostBinding, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'rocc-settings',
+  templateUrl: './settings.component.html',
+  styleUrls: ['./settings.component.scss'],
+})
+export class SettingsComponent implements OnInit {
+  @HostBinding('class.main-content') readonly mainContentClass = true;
+
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/pages/settings/settings.component.ts
+++ b/src/app/pages/settings/settings.component.ts
@@ -5,10 +5,8 @@ import { Component, HostBinding, OnInit } from '@angular/core';
   templateUrl: './settings.component.html',
   styleUrls: ['./settings.component.scss'],
 })
-export class SettingsComponent implements OnInit {
+export class SettingsComponent {
   @HostBinding('class.main-content') readonly mainContentClass = true;
 
   constructor() {}
-
-  ngOnInit(): void {}
 }

--- a/src/app/pages/settings/settings.module.ts
+++ b/src/app/pages/settings/settings.module.ts
@@ -2,11 +2,18 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SettingsComponent } from './settings.component';
 import { FooterModule } from '@sage-bionetworks/sage-angular';
+import { AuthModule } from '@shared/auth/auth.module';
 import { MaterialModule } from '@app/shared/material/material.module';
 import { SettingsRoutingModule } from './settings-routing.module';
 
 @NgModule({
-  imports: [CommonModule, FooterModule, MaterialModule, SettingsRoutingModule],
+  imports: [
+    CommonModule,
+    FooterModule,
+    AuthModule,
+    MaterialModule,
+    SettingsRoutingModule,
+  ],
   declarations: [SettingsComponent],
 })
 export class SettingsModule {}

--- a/src/app/pages/settings/settings.module.ts
+++ b/src/app/pages/settings/settings.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SettingsComponent } from './settings.component';
+import { FooterModule } from '@sage-bionetworks/sage-angular';
+import { MaterialModule } from '@app/shared/material/material.module';
+import { SettingsRoutingModule } from './settings-routing.module';
+
+@NgModule({
+  imports: [CommonModule, FooterModule, MaterialModule, SettingsRoutingModule],
+  declarations: [SettingsComponent],
+})
+export class SettingsModule {}

--- a/src/app/pages/signin/signin.component.ts
+++ b/src/app/pages/signin/signin.component.ts
@@ -106,7 +106,7 @@ export class SigninComponent implements OnInit, OnDestroy {
     this.errors.other = undefined;
 
     this.authService
-      .login(this.username?.value, this.password?.value)
+      .signin(this.username?.value, this.password?.value)
       .subscribe(
         () => {
           this.router.navigate([this.authService.getRedirectUrl()]);

--- a/src/app/shared/auth/auth-guard.service.ts
+++ b/src/app/shared/auth/auth-guard.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import {
+  CanActivate,
+  Router,
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot,
+} from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+import { AuthService } from './auth.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AuthGuard implements CanActivate {
+  constructor(private router: Router, private authService: AuthService) {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean> | boolean {
+    return this.authService.isSignedIn().pipe(
+      map((signedIn) => {
+        if (!signedIn) {
+          this.authService.setRedirectUrl(state.url);
+          this.router.navigate([this.authService.getSigninUrl()]);
+        }
+        return signedIn;
+      }),
+      catchError((err) => {
+        console.error(err);
+        return of(false);
+      })
+    );
+  }
+}

--- a/src/app/shared/auth/auth.service.ts
+++ b/src/app/shared/auth/auth.service.ts
@@ -38,7 +38,7 @@ export class AuthService {
   >(undefined);
   private initialized = false;
 
-  // private loginUrl = '/login';
+  private loginUrl = '/signin';
   private redirectUrl = '/';
 
   constructor(
@@ -54,7 +54,7 @@ export class AuthService {
     });
   }
 
-  login(login: string, password: string): Observable<User> {
+  signin(login: string, password: string): Observable<User> {
     const localAuthRequest: LocalAuthRequest = {
       login: login,
       password: password,
@@ -71,7 +71,7 @@ export class AuthService {
     );
   }
 
-  logout(): Observable<null> {
+  signout(): Observable<null> {
     this.tokenService.deleteToken();
     this.user.next(undefined);
     return of(null);
@@ -97,5 +97,9 @@ export class AuthService {
 
   setRedirectUrl(redirectUrl: string): void {
     this.redirectUrl = redirectUrl;
+  }
+
+  getSigninUrl(): string {
+    return this.loginUrl;
   }
 }


### PR DESCRIPTION
Fixes #217 

## Notes

- Add route `/settings`
  - The route is protected by the `AuthGuard` service: if the user is not signed in, the guard redirect to the sign in page. Upon successfully sign in, the user is redirected to the page it intended to reach.