### PR TITLE
List the orgs a user belong to

### DIFF
--- a/src/app/pages/account/user-account/user-account.component.html
+++ b/src/app/pages/account/user-account/user-account.component.html
@@ -3,7 +3,7 @@
   </rocc-user-profile-bar>
   <mat-tab-group animationDuration="0ms">
     <mat-tab label="Overview">
-      <rocc-user-profile-overview [user]="user"></rocc-user-profile-overview>
+      <rocc-user-profile-overview [user]="user" [orgs]="orgs"></rocc-user-profile-overview>
     </mat-tab>
     <mat-tab label="Challenges">
       <rocc-user-profile-challenges [userId]="accountId"></rocc-user-profile-challenges>

--- a/src/app/pages/account/user-account/user-account.component.html
+++ b/src/app/pages/account/user-account/user-account.component.html
@@ -1,5 +1,5 @@
 <div class="container" *ngIf="user$ | async as user">
-  <rocc-user-profile-bar [user]="user" class="user-profile-sticky-bar">
+  <rocc-user-profile-bar [user]="user" [numOrgs]="orgs.length" class="user-profile-sticky-bar">
   </rocc-user-profile-bar>
   <mat-tab-group animationDuration="0ms">
     <mat-tab label="Overview">

--- a/src/app/pages/account/user-account/user-account.component.ts
+++ b/src/app/pages/account/user-account/user-account.component.ts
@@ -1,19 +1,36 @@
-import { Component, Input, OnInit } from '@angular/core';
-import { UserService, User } from '@sage-bionetworks/rocc-client-angular';
-import { Observable } from 'rxjs';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import {
+  UserService,
+  User,
+  Organization,
+} from '@sage-bionetworks/rocc-client-angular';
+import { Observable, Subscription } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'rocc-user-account',
   templateUrl: './user-account.component.html',
   styleUrls: ['./user-account.component.scss'],
 })
-export class UserAccountComponent implements OnInit {
+export class UserAccountComponent implements OnInit, OnDestroy {
   @Input() accountId!: string;
   user$!: Observable<User>;
+  orgs: Organization[] = [];
+  private subscriptions: Subscription[] = [];
 
   constructor(private userService: UserService) {}
 
   ngOnInit(): void {
     this.user$ = this.userService.getUser(this.accountId);
+
+    const orgsSub = this.userService
+      .listUserOrganizations(this.accountId)
+      .pipe(map((page) => page.organizations))
+      .subscribe((orgs) => (this.orgs = orgs));
+    this.subscriptions.push(orgsSub);
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach(sub => sub.unsubscribe());
   }
 }

--- a/src/app/pages/account/user-account/user-profile-bar/user-profile-bar.component.html
+++ b/src/app/pages/account/user-account/user-profile-bar/user-profile-bar.component.html
@@ -9,19 +9,19 @@
       </mat-icon>
     </div>
     <div class="rocc-user-page-bar-detail-container">
-      <a class="rocc-user-page-bar-organizations-container" routerLink="/{{user.login}}">
+      <span class="rocc-user-page-bar-organizations-container">
         <mat-icon>home_work</mat-icon>
         <span class="rocc-user-page-bar-organizations">
-          <strong>{{numOrgs$ | async}}</strong>  organizations
+          <strong>{{numOrgs}}</strong> organizations
         </span>
-      </a>
+      </span>
       <span class="dot"> · </span>
-      <a class="rocc-user-page-bar-favorites-container" routerLink="/{{user.login}}">
+      <span class="rocc-user-page-bar-favorites-container">
         <mat-icon>star</mat-icon>
         <span class="rocc-user-page-bar-favorites">
           <strong>{{numStarredChallenges$ | async}}</strong>
         </span>
-      </a>
+      </span>
     </div>
     <button mat-raised-button>Edit your profile</button>
   </div>

--- a/src/app/pages/account/user-account/user-profile-bar/user-profile-bar.component.ts
+++ b/src/app/pages/account/user-account/user-profile-bar/user-profile-bar.component.ts
@@ -13,7 +13,7 @@ import { User, UserService } from '@sage-bionetworks/rocc-client-angular';
 export class UserProfileBarComponent implements OnInit {
   @Input() user!: User;
   @Input() userAvatar!: Avatar;
-  numOrgs$!: Observable<number>;
+  @Input() numOrgs = 0;
 
   // mock up summary data
   isVerified = true;
@@ -29,13 +29,6 @@ export class UserProfileBarComponent implements OnInit {
       src: this.user.avatarUrl!,
       size: 160,
     };
-
-    this.numOrgs$ = this.userService
-      .listUserOrganizations(this.user.id, 50, 0)
-      .pipe(
-        map((page) => page.organizations),
-        map((orgs) => (orgs === undefined ? 0 : orgs.length))
-      );
 
     this.numStarredChallenges$ = this.userService
       .listUserStarredChallenges(this.user.id, 10, 0)

--- a/src/app/pages/account/user-account/user-profile-bar/user-profile-bar.component.ts
+++ b/src/app/pages/account/user-account/user-profile-bar/user-profile-bar.component.ts
@@ -1,13 +1,9 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { Avatar } from '@sage-bionetworks/sage-angular/src/lib/avatar';
-import {
-  OrgMembershipService,
-  User,
-} from '@sage-bionetworks/rocc-client-angular';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { map as _map, uniqBy as _uniqBy } from 'lodash-es';
-import { UserService } from '@sage-bionetworks/rocc-client-angular';
+import { Avatar } from '@sage-bionetworks/sage-angular';
+import { User, UserService } from '@sage-bionetworks/rocc-client-angular';
 
 @Component({
   selector: 'rocc-user-profile-bar',
@@ -23,10 +19,7 @@ export class UserProfileBarComponent implements OnInit {
   isVerified = true;
   numStarredChallenges$!: Observable<number>;
 
-  constructor(
-    private orgMembershipService: OrgMembershipService,
-    private userService: UserService
-  ) {}
+  constructor(private userService: UserService) {}
 
   ngOnInit(): void {
     this.userAvatar = {
@@ -37,18 +30,15 @@ export class UserProfileBarComponent implements OnInit {
       size: 160,
     };
 
-    this.numOrgs$ = this.orgMembershipService
-      .listOrgMemberships(50, 0, undefined, this.user.id)
+    this.numOrgs$ = this.userService
+      .listUserOrganizations(this.user.id, 50, 0)
       .pipe(
-        map((page) => page.orgMemberships),
-        map((orgMemberships) =>
-          _map(_uniqBy(orgMemberships, 'organizationId'), 'organizationId')
-        ),
-        map((orgIds) => (orgIds === undefined ? 0 : orgIds.length))
+        map((page) => page.organizations),
+        map((orgs) => (orgs === undefined ? 0 : orgs.length))
       );
 
     this.numStarredChallenges$ = this.userService
       .listUserStarredChallenges(this.user.id, 10, 0)
-      .pipe(map(page => page.totalResults));
+      .pipe(map((page) => page.totalResults));
   }
 }

--- a/src/app/pages/account/user-account/user-profile-overview/user-profile-overview.component.html
+++ b/src/app/pages/account/user-account/user-profile-overview/user-profile-overview.component.html
@@ -3,5 +3,6 @@
 
 <h2>Organizations</h2>
 <mat-nav-list>
-  <a mat-list-item [href]="org.login" *ngFor="let org of orgs">{{org.login}}</a>
+  <a mat-list-item [routerLink]="['/', org.login]"
+    *ngFor="let org of orgs">{{org.login}}</a>
 </mat-nav-list>

--- a/src/app/pages/account/user-account/user-profile-overview/user-profile-overview.component.html
+++ b/src/app/pages/account/user-account/user-profile-overview/user-profile-overview.component.html
@@ -1,2 +1,7 @@
 <p>user-profile-overview works!</p>
 <p>{{user | json}}</p>
+
+<h2>Organizations</h2>
+<mat-nav-list>
+  <a mat-list-item [href]="org.login" *ngFor="let org of orgs">{{org.login}}</a>
+</mat-nav-list>

--- a/src/app/pages/account/user-account/user-profile-overview/user-profile-overview.component.ts
+++ b/src/app/pages/account/user-account/user-profile-overview/user-profile-overview.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { User } from '@sage-bionetworks/rocc-client-angular';
+import { Organization, User } from '@sage-bionetworks/rocc-client-angular';
 
 @Component({
   selector: 'rocc-user-profile-overview',
@@ -8,6 +8,7 @@ import { User } from '@sage-bionetworks/rocc-client-angular';
 })
 export class UserProfileOverviewComponent {
   @Input() user!: User;
+  @Input() orgs: Organization[] = [];
 
   constructor() {}
 }


### PR DESCRIPTION
Fixes #233 

## Notes

- Use new endpoints to get the orgs a user belongs to.
- Listing orgs in the tab `Overview` for now.

## Preview

![image](https://user-images.githubusercontent.com/3056480/133707022-83befea5-1722-4206-81e3-30e77b0534b7.png)
