### PR TITLE
Star and unstar challenges

### DIFF
--- a/src/app/pages/challenge/challenge-data.service.ts
+++ b/src/app/pages/challenge/challenge-data.service.ts
@@ -1,23 +1,57 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, Observable, merge } from 'rxjs';
-import { filter, switchMap, tap } from 'rxjs/operators';
+import {
+  BehaviorSubject,
+  Observable,
+  merge,
+  throwError,
+  combineLatest,
+} from 'rxjs';
+import {
+  catchError,
+  filter,
+  mapTo,
+  switchMap,
+  take,
+  tap,
+} from 'rxjs/operators';
 import {
   Challenge,
   ChallengeService,
   ChallengeReadme,
+  ModelError as RoccClientError,
+  UserService,
 } from '@sage-bionetworks/rocc-client-angular';
 import { isDefined, isUndefined } from '@app/type-guards';
+import { of } from 'rxjs';
+import { isRoccClientError } from '@app/shared/rocc-client-error';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ChallengeDataService {
+  // private challengeData: BehaviorSubject<ChallengeData | undefined> =
+  //   new BehaviorSubject<ChallengeData | undefined>(undefined);
+
   private challenge: BehaviorSubject<Challenge | undefined> =
     new BehaviorSubject<Challenge | undefined>(undefined);
   private readme: BehaviorSubject<ChallengeReadme | null> =
     new BehaviorSubject<ChallengeReadme | null>(null);
+  private starred: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
+    false
+  );
 
-  constructor(private challengeService: ChallengeService) {}
+  constructor(
+    private challengeService: ChallengeService,
+    private userService: UserService
+  ) {}
+
+  fetchChallenge(owner: string, name: string): Observable<Challenge> {
+    return this.challengeService.getChallenge(owner, name).pipe(
+      tap((challenge) => this.challenge.next(challenge)),
+      switchMap(() => this.challenge.asObservable()),
+      filter(isDefined)
+    );
+  }
 
   setChallenge(challenge: Challenge | undefined): void {
     this.readme.next(null);
@@ -54,6 +88,68 @@ export class ChallengeDataService {
       switchMap((challenge) =>
         merge(getReadmeFromCache, getReadmeFromApi(challenge))
       )
+    );
+  }
+
+  fetchStarred(): Observable<boolean> {
+    return this.challenge.pipe(
+      filter(isDefined),
+      switchMap((challenge) =>
+        this.userService.isStarredChallenge(
+          challenge.fullName.split('/')[0],
+          challenge.name
+        )
+      ),
+      mapTo(true),
+      catchError((err) => {
+        const error = err.error as RoccClientError;
+        if (isRoccClientError(error)) {
+          if (error.status == 404) {
+            return of(false);
+          }
+        }
+        throwError(err);
+        return of(false);
+      }),
+      tap((starred) => this.starred.next(starred)),
+      switchMap(() => this.starred.asObservable())
+    );
+  }
+
+  getStarred(): Observable<boolean> {
+    return this.starred.asObservable();
+  }
+
+  toggleStarred(): Observable<boolean> {
+    const data$ = combineLatest([this.challenge, this.starred]).pipe(take(1));
+
+    const star$: Observable<boolean> = data$.pipe(
+      filter(([_, starred]) => !starred),
+      switchMap(([challenge, _]) => {
+        if (challenge !== undefined) {
+          return this.userService
+            .starChallenge(challenge.fullName.split('/')[0], challenge.name)
+            .pipe(mapTo(true));
+        }
+        return of(false);
+      })
+    );
+
+    const unstar$: Observable<boolean> = data$.pipe(
+      filter(([_, starred]) => starred),
+      switchMap(([challenge, _]) => {
+        if (challenge !== undefined) {
+          return this.userService
+            .unstarChallenge(challenge.fullName.split('/')[0], challenge.name)
+            .pipe(mapTo(false));
+        }
+        return of(false);
+      })
+    );
+
+    return merge(star$, unstar$).pipe(
+      tap((starred) => this.starred.next(starred)),
+      switchMap(() => this.starred.asObservable())
     );
   }
 }

--- a/src/app/pages/challenge/challenge-data.service.ts
+++ b/src/app/pages/challenge/challenge-data.service.ts
@@ -55,6 +55,7 @@ export class ChallengeDataService {
 
   setChallenge(challenge: Challenge | undefined): void {
     this.readme.next(null);
+    this.starred.next(false);
     this.challenge.next(challenge);
   }
 

--- a/src/app/pages/challenge/challenge-header/challenge-header.component.html
+++ b/src/app/pages/challenge/challenge-header/challenge-header.component.html
@@ -9,7 +9,7 @@
       </div>
       <div class="rocc-challenge-detail-title-container">
         <span>{{challenge.displayName}}</span>
-        <button mat-icon-button (click)="toggleStarred()">
+        <button mat-icon-button (click)="toggleStarred()" [matTooltip]="getStarredTooltip()">
           <mat-icon *ngIf="starred" class="rocc-challenge-favorite-icon" inline=true>
             star
           </mat-icon>

--- a/src/app/pages/challenge/challenge-header/challenge-header.component.html
+++ b/src/app/pages/challenge/challenge-header/challenge-header.component.html
@@ -9,14 +9,14 @@
       </div>
       <div class="rocc-challenge-detail-title-container">
         <span>{{challenge.displayName}}</span>
-        <button mat-icon-button (click)="toggleSelected()">
-          <mat-icon *ngIf="isFavorite" class="rocc-challenge-favorite-icon" inline=true>
+        <button mat-icon-button (click)="toggleStarred()">
+          <mat-icon *ngIf="starred" class="rocc-challenge-favorite-icon" inline=true>
             star
           </mat-icon>
-          <mat-icon *ngIf="!isFavorite" inline=true>
+          <mat-icon *ngIf="!starred" inline=true>
             star_border
           </mat-icon>
-        </button> 
+        </button>
       </div>
       <div class="rocc-challenge-detail-header-status-container">
         <span>{{challenge.status | titlecase}}</span>

--- a/src/app/pages/challenge/challenge-header/challenge-header.component.ts
+++ b/src/app/pages/challenge/challenge-header/challenge-header.component.ts
@@ -1,10 +1,11 @@
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 import {
   ChallengePlatformService,
   Challenge,
   ChallengePlatform,
 } from '@sage-bionetworks/rocc-client-angular';
 import { Observable } from 'rxjs';
+import { ChallengeDataService } from '../challenge-data.service';
 
 @Component({
   selector: 'rocc-challenge-header',
@@ -14,19 +15,25 @@ import { Observable } from 'rxjs';
 export class ChallengeHeaderComponent implements OnInit {
   @Input() accountName = '';
   @Input() challenge!: Challenge;
-  @Input() isFavorite!: boolean;
-  @Output() selectedChange = new EventEmitter<boolean>();
+  starred = false;
 
   progressValue!: number;
   remainDays!: number | undefined;
   platform$!: Observable<ChallengePlatform>;
 
-  constructor(private challengePlatformService: ChallengePlatformService) {}
+  constructor(
+    private challengePlatformService: ChallengePlatformService,
+    private challengeDataService: ChallengeDataService
+  ) {}
 
   ngOnInit(): void {
     this.platform$ = this.challengePlatformService.getChallengePlatform(
       this.challenge?.platformId!
     );
+
+    this.challengeDataService
+      .getStarred()
+      .subscribe((starred) => (this.starred = starred));
 
     this.progressValue =
       this.challenge.status == 'active'
@@ -61,8 +68,10 @@ export class ChallengeHeaderComponent implements OnInit {
     );
   }
 
-  public toggleSelected() {
-    this.isFavorite = !this.isFavorite;
-    this.selectedChange.emit(this.isFavorite);
+  toggleStarred() {
+    this.starred = !this.starred;
+    this.challengeDataService
+      .toggleStarred()
+      .subscribe((starred) => console.log('Challenge starred', starred));
   }
 }

--- a/src/app/pages/challenge/challenge-header/challenge-header.component.ts
+++ b/src/app/pages/challenge/challenge-header/challenge-header.component.ts
@@ -95,9 +95,7 @@ export class ChallengeHeaderComponent implements OnInit {
   toggleStarred(): void {
     if (this.loggedIn) {
       this.starred = !this.starred;
-      this.challengeDataService
-        .toggleStarred()
-        .subscribe((starred) => console.log('Challenge starred', starred));
+      this.challengeDataService.toggleStarred().subscribe();
     } else {
       this.authService.setRedirectUrl(this.router.url);
       this.router.navigate(['signin']);

--- a/src/app/pages/challenge/challenge-header/challenge-header.component.ts
+++ b/src/app/pages/challenge/challenge-header/challenge-header.component.ts
@@ -99,6 +99,7 @@ export class ChallengeHeaderComponent implements OnInit {
         .toggleStarred()
         .subscribe((starred) => console.log('Challenge starred', starred));
     } else {
+      this.authService.setRedirectUrl(this.router.url);
       this.router.navigate(['signin']);
     }
   }

--- a/src/app/pages/challenge/challenge.component.html
+++ b/src/app/pages/challenge/challenge.component.html
@@ -1,8 +1,6 @@
 <main>
   <div class="container" *ngIf="challenge$ | async as challenge">
-    <rocc-challenge-header 
-      [challenge]="challenge" 
-      [accountName]="accountName">
+    <rocc-challenge-header [challenge]="challenge" [accountName]="accountName">
     </rocc-challenge-header>
     <nav mat-tab-nav-bar>
       <a mat-tab-link *ngFor="let section of sections"

--- a/src/app/pages/challenge/challenge.module.ts
+++ b/src/app/pages/challenge/challenge.module.ts
@@ -9,6 +9,7 @@ import { ChallengeHeaderComponent } from './challenge-header/challenge-header.co
 import { ChallengeOverviewComponent } from './challenge-overview/challenge-overview.component';
 import { ChallengeSettingsComponent } from './challenge-settings/challenge-settings.component';
 import { ChallengeNewComponent } from './challenge-new/challenge-new.component';
+import { AuthModule } from '@shared/auth/auth.module';
 
 @NgModule({
   imports: [
@@ -17,6 +18,7 @@ import { ChallengeNewComponent } from './challenge-new/challenge-new.component';
     FooterModule,
     MaterialModule,
     NotFoundModule,
+    AuthModule
   ],
   declarations: [
     ChallengeComponent,

--- a/src/app/pages/signup/signup.component.ts
+++ b/src/app/pages/signup/signup.component.ts
@@ -117,7 +117,6 @@ export class SignupComponent implements OnInit {
 
     this.userService.createUser(userCreateRequest).subscribe(
       (res) => {
-        console.log('UserCreateResponse:', res);
         this.router.navigate(['signin']);
       },
       (err) => {


### PR DESCRIPTION
- Fixes #251 
- Fixes #253 

## Note

When reaching a challenge page and IF the user is authenticated, the challenge component triggers the fetch of whether the challenge is starred or not. The fetching logic and the `starred` state are defined in `ChallengeDataService`. The challenge header component get the `starred` status from the data service. The data service also includes a method to toggle the `starred` status for a challenge.

## Future improvements

- #253 
- #255