### PR TITLE
Add persistent volume to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - MONGO_PASSWORD
     networks:
       - rocc-networks
+    volumes:
+      - rocc-data:/data/db
 
   rocc-service:
     image: sagebionetworks/rocc-service:0.8.0
@@ -56,3 +58,7 @@ services:
 
 networks:
   rocc-networks:
+
+volumes:
+  rocc-data:
+    name: rocc-data


### PR DESCRIPTION
Fix #354 

Running `docker compose down` does not remove volumes created when starting the stack for the first time. If the stack is restarted after having shut it down, the existing volume will be reused.