### PR TITLE
Update app to use latest sage-angular package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     - run: npm install -g npm@8.4.0
 
     - name: Install dependencies
-      run: npm run install:dependencies
+      run: npm ci
 
     - name: Run lint checks
       run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
       with:
         node-version: ${{ env.node_version }}
 
+    - run: npm install -g npm@8.4.0
+
     - name: Install dependencies
       run: npm run install:dependencies
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
 # Build the Angular app
-FROM node:16.2.0-alpine3.12 as build
+FROM node:16.10.0-slim as build
 WORKDIR /app
 COPY rocc-client-angular rocc-client-angular/
 COPY sage-angular sage-angular/
 COPY src src/
 COPY angular.json package.json package-lock.json tsconfig.app.json \
     tsconfig.json tsconfig.spec.json .eslintrc.json ./
-RUN npm run install:dependencies \
-    && npm run build
+RUN npm install -g npm@8.4.0
+RUN npm ci
+RUN npm run build
 
 # Setup nginx
-FROM nginx:1.21.0-alpine
+FROM nginx:1.21.6-alpine
 COPY --from=build /app/dist/rocc-app /usr/share/nginx/html
 COPY nginx/nginx.conf /etc/nginx/nginx.conf
 COPY nginx/templates /etc/nginx/templates

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ or more of the linked repositories.
        docker compose up --build
 
    - access the app on http://localhost:80 by default
-   - access the swagger UI on http://localhost:8080/api/v1
+   - access the swagger UI on http://localhost:80/api/v1/ui
 
 ### Running with Angular CLI
 
@@ -49,9 +49,9 @@ project root folder.
 
 2. Install the dependencies.
 
-       npm run install:dependencies
+       npm ci
 
-3. Start the [ROCC API service] on http://localhost:8080/api/v1
+3. Start the [ROCC API service] using Python on http://localhost:8080/api/v1
 
 4. Start the web client (uses Angular CLI).
 
@@ -65,9 +65,9 @@ The ROCC app is dependent on two linked repositories (a.k.a. submodules):
 * [sage-angular]
 
 When an update is pushed to one or more of the linked repository(ies), you
-will need to update those references on your end as well.  The steps are:
+will need to update those references on your end as well. The steps are:
 
-1. Pull the latest changes, which will also fetch the updates made to the 
+1. Pull the latest changes, which will also fetch the updates made to the
 configuration files for the linked repos.
 
        git checkout main
@@ -77,17 +77,12 @@ configuration files for the linked repos.
 
        git submodule update
 
-3. Re-build the appropriate client(s).
-
-       npm run build:rocc-client-angular
-       npm run build:sage-angular
-
-4. (optional) If new packages have been added to the client, those packages
+3. (optional) If new packages have been added to the client, those packages
 will need to be installed.
 
        npm ci
 
-5. To test, start the web client.
+4. To test, start the web client.
 
        npm start
 
@@ -175,7 +170,7 @@ Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protrac
 
 ## Further help
 
-To get more help on the Angular CLI use `ng help` or go check out the 
+To get more help on the Angular CLI use `ng help` or go check out the
 [Angular CLI Overview and Command Reference](https://angular.io/cli) page.
 
 ## License

--- a/angular.json
+++ b/angular.json
@@ -44,7 +44,10 @@
               "node_modules/primeng/resources/primeng.min.css"
             ],
             "stylePreprocessorOptions": {
-              "includePaths": ["src/app/pages"]
+              "includePaths": [
+                "src/app/pages",
+                "node_modules/@sage-bionetworks"
+              ]
             },
             "scripts": [],
             "preserveSymlinks": true,

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "start": "ng serve --proxy-config proxy.conf.json",
     "build": "ng build --configuration production",
     "build:rocc-client-angular": "cd rocc-client-angular && npm ci --legacy-peer-deps && npm run build",
-    "build:sage-angular": "cd sage-angular && npm ci && npm run build",
-    "install:dependencies": "npm run build:rocc-client-angular && npm run build:sage-angular && npm ci --legacy-peer-deps",
+    "build:sage-angular": "cd sage-angular && npm ci --legacy-peer-deps && npm run build",
     "test": "ng test",
     "e2e": "ng e2e",
     "analyze": "ng build --prod --stats-json && webpack-bundle-analyzer ./dist/rocc-app/stats.json",
@@ -16,7 +15,8 @@
     "lint": "eslint 'src/**/*.ts'",
     "lint:fix": "eslint 'src/**/*.ts' --fix",
     "lint-staged": "lint-staged",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "preinstall": "npm run build:rocc-client-angular && npm run build:sage-angular"
   },
   "engines": {
     "node": ">=14.16.1",

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,9 +1,9 @@
 @import './styles/constants';
 @import './styles/general';
-@import '@sage-bionetworks/sage-angular/src/styles';
+@import 'sage-angular/src/styles';
 
 @import 'app-theme';
-@import '@sage-bionetworks/sage-angular/src/lib-theme';
+@import 'sage-angular/src/lib-theme';
 
 // Include material core styles.
 @include mat-core();


### PR DESCRIPTION
## Changelogs

- Use new version of sage-angular, which now use Angular `13.2`
- After the update, the only issue this app had was about importing `sage-angular` scss styles. This issue is fixed in `angular.json` and the app `styles.scss`.
- Make use of npm script `preinstall` to build the submodules `rocc-client-angular` and `sage-angular`
