### PR TITLE
Add required stylePreprocessorOptions to Angular test target

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -116,7 +116,10 @@
               "src/styles.scss"
             ],
             "stylePreprocessorOptions": {
-              "includePaths": ["src/app/pages"]
+              "includePaths": [
+                "src/app/pages",
+                "node_modules/@sage-bionetworks"
+              ]
             },
             "scripts": []
           }


### PR DESCRIPTION
Fixes #376 

This was an easy fix: I just add to add the required `stylePreprocessorOptions` to the Angular target `test`. I recently applied the same change to the target `serve` right after updating the library `sage-angular`.